### PR TITLE
refactor: WebSocket 에러 처리 이벤트 기반 아키텍처로 개선

### DIFF
--- a/src/main/java/com/swygbro/airoad/backend/common/domain/event/WebSocketErrorEvent.java
+++ b/src/main/java/com/swygbro/airoad/backend/common/domain/event/WebSocketErrorEvent.java
@@ -1,0 +1,18 @@
+package com.swygbro.airoad.backend.common.domain.event;
+
+import com.swygbro.airoad.backend.common.domain.dto.ErrorResponse;
+
+/**
+ * WebSocket 에러 전송 이벤트
+ *
+ * <p>WebSocket 인터셉터에서 발생한 에러를 에러 채널로 전송하기 위한 이벤트입니다.
+ *
+ * <p>이벤트 기반 아키텍처를 통해 {@code JwtWebSocketInterceptor}와 {@code SimpMessagingTemplate} 간의 순환 참조를
+ * 해결합니다.
+ *
+ * @param userId 사용자 ID (이메일)
+ * @param errorChannel 에러 채널 경로 (예: /sub/errors/123)
+ * @param errorResponse 에러 응답 DTO
+ */
+public record WebSocketErrorEvent(
+    String userId, String errorChannel, ErrorResponse errorResponse) {}

--- a/src/main/java/com/swygbro/airoad/backend/common/presentation/WebSocketErrorEventListener.java
+++ b/src/main/java/com/swygbro/airoad/backend/common/presentation/WebSocketErrorEventListener.java
@@ -1,0 +1,51 @@
+package com.swygbro.airoad.backend.common.presentation;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import com.swygbro.airoad.backend.common.domain.event.WebSocketErrorEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * WebSocket 에러 이벤트 리스너
+ *
+ * <p>{@link WebSocketErrorEvent}를 수신하여 클라이언트에게 에러 메시지를 전송합니다.
+ *
+ * <p>이벤트 기반 아키텍처를 통해 {@code JwtWebSocketInterceptor}와 {@code SimpMessagingTemplate} 간의 순환 참조를
+ * 해결합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketErrorEventListener {
+
+  private final SimpMessagingTemplate messagingTemplate;
+
+  /**
+   * WebSocket 에러 이벤트를 처리합니다.
+   *
+   * <p>에러 메시지를 사용자별 에러 채널로 전송합니다.
+   *
+   * @param event WebSocket 에러 이벤트
+   */
+  @EventListener
+  public void handleWebSocketError(WebSocketErrorEvent event) {
+    try {
+      messagingTemplate.convertAndSendToUser(
+          event.userId(), event.errorChannel(), event.errorResponse());
+
+      log.info(
+          "[WebSocket] 에러 이벤트 처리 완료 - userId: {}, channel: {}, code: {}",
+          event.userId(),
+          event.errorChannel(),
+          event.errorResponse().code());
+
+    } catch (Exception e) {
+      log.error(
+          "[WebSocket] 에러 이벤트 처리 실패 - userId: {}, error: {}", event.userId(), e.getMessage(), e);
+    }
+  }
+}

--- a/src/test/java/com/swygbro/airoad/backend/common/config/JwtWebSocketInterceptorTest.java
+++ b/src/test/java/com/swygbro/airoad/backend/common/config/JwtWebSocketInterceptorTest.java
@@ -8,11 +8,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.MessageBuilder;
@@ -27,6 +28,7 @@ import com.swygbro.airoad.backend.auth.application.UserDetailsServiceImpl;
 import com.swygbro.airoad.backend.auth.domain.entity.TokenType;
 import com.swygbro.airoad.backend.auth.filter.JwtTokenProvider;
 import com.swygbro.airoad.backend.chat.config.JwtWebSocketInterceptor;
+import com.swygbro.airoad.backend.common.domain.event.WebSocketErrorEvent;
 import com.swygbro.airoad.backend.common.exception.WebSocketErrorCode;
 
 import static org.assertj.core.api.Assertions.*;
@@ -47,7 +49,7 @@ class JwtWebSocketInterceptorTest {
 
   @Mock private UserDetailsServiceImpl userDetailsService;
 
-  @Mock private SimpMessagingTemplate messagingTemplate;
+  @Mock private ApplicationEventPublisher eventPublisher;
 
   @InjectMocks private JwtWebSocketInterceptor interceptor;
 
@@ -221,8 +223,8 @@ class JwtWebSocketInterceptorTest {
     }
 
     @Test
-    @DisplayName("허용되지 않은 경로로 메시지 전송 시 에러 채널로 전송하고 null을 반환한다")
-    void shouldSendToErrorChannelWhenSendingToForbiddenPath() {
+    @DisplayName("허용되지 않은 경로로 메시지 전송 시 에러 이벤트를 발행하고 null을 반환한다")
+    void shouldPublishErrorEventWhenSendingToForbiddenPath() {
       // given
       StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SEND);
       accessor.setDestination("/pub/other/message"); // 허용되지 않은 경로
@@ -235,9 +237,17 @@ class JwtWebSocketInterceptorTest {
       // then
       assertThat(result).isNull(); // SEND 에러는 null 반환 (메시지 전달 중단)
 
-      // 에러 채널로 전송 검증
-      verify(messagingTemplate)
-          .convertAndSendToUser(eq(USER_EMAIL), eq("/sub/errors/unknown"), any());
+      // 에러 이벤트 발행 검증
+      ArgumentCaptor<WebSocketErrorEvent> eventCaptor =
+          ArgumentCaptor.forClass(WebSocketErrorEvent.class);
+      verify(eventPublisher).publishEvent(eventCaptor.capture());
+
+      WebSocketErrorEvent event = eventCaptor.getValue();
+      assertThat(event.userId()).isEqualTo(USER_EMAIL);
+      assertThat(event.errorChannel()).isEqualTo("/sub/errors/unknown");
+      assertThat(event.errorResponse()).isNotNull();
+      assertThat(event.errorResponse().code())
+          .isEqualTo(WebSocketErrorCode.FORBIDDEN_SEND.getCode());
     }
   }
 

--- a/src/test/java/com/swygbro/airoad/backend/common/presentation/WebSocketErrorEventListenerTest.java
+++ b/src/test/java/com/swygbro/airoad/backend/common/presentation/WebSocketErrorEventListenerTest.java
@@ -1,0 +1,111 @@
+package com.swygbro.airoad.backend.common.presentation;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.swygbro.airoad.backend.common.domain.dto.ErrorResponse;
+import com.swygbro.airoad.backend.common.domain.event.WebSocketErrorEvent;
+
+import static org.mockito.BDDMockito.*;
+
+/**
+ * WebSocketErrorEventListener 테스트
+ *
+ * <p>WebSocket 에러 이벤트 리스너의 동작을 검증합니다.
+ */
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+@DisplayName("WebSocketErrorEventListener")
+class WebSocketErrorEventListenerTest {
+
+  @Mock private SimpMessagingTemplate messagingTemplate;
+
+  @InjectMocks private WebSocketErrorEventListener listener;
+
+  private static final String USER_ID = "user@example.com";
+  private static final String ERROR_CHANNEL = "/sub/errors/123";
+  private static final String ERROR_CODE = "WS001";
+  private static final String ERROR_MESSAGE = "WebSocket 에러 발생";
+
+  @Nested
+  @DisplayName("handleWebSocketError 메서드는")
+  class HandleWebSocketError {
+
+    @Test
+    @DisplayName("WebSocketErrorEvent를 받아 SimpMessagingTemplate로 에러를 전송한다")
+    void shouldSendErrorMessageToUser() {
+      // given
+      ErrorResponse errorResponse = ErrorResponse.of(ERROR_CODE, ERROR_MESSAGE, "/pub/chat/123");
+      WebSocketErrorEvent event = new WebSocketErrorEvent(USER_ID, ERROR_CHANNEL, errorResponse);
+
+      // when
+      listener.handleWebSocketError(event);
+
+      // then
+      verify(messagingTemplate).convertAndSendToUser(USER_ID, ERROR_CHANNEL, errorResponse);
+    }
+
+    @Test
+    @DisplayName("여러 WebSocketErrorEvent를 순차적으로 처리한다")
+    void shouldHandleMultipleEvents() {
+      // given
+      ErrorResponse errorResponse1 = ErrorResponse.of("WS001", "첫 번째 에러", "/pub/chat/123");
+      ErrorResponse errorResponse2 = ErrorResponse.of("WS002", "두 번째 에러", "/pub/chat/456");
+
+      WebSocketErrorEvent event1 =
+          new WebSocketErrorEvent("user1@example.com", "/sub/errors/123", errorResponse1);
+      WebSocketErrorEvent event2 =
+          new WebSocketErrorEvent("user2@example.com", "/sub/errors/456", errorResponse2);
+
+      // when
+      listener.handleWebSocketError(event1);
+      listener.handleWebSocketError(event2);
+
+      // then
+      verify(messagingTemplate)
+          .convertAndSendToUser("user1@example.com", "/sub/errors/123", errorResponse1);
+      verify(messagingTemplate)
+          .convertAndSendToUser("user2@example.com", "/sub/errors/456", errorResponse2);
+    }
+
+    @Test
+    @DisplayName("SimpMessagingTemplate에서 예외 발생 시에도 실패하지 않는다")
+    void shouldNotFailWhenMessagingTemplateFails() {
+      // given
+      ErrorResponse errorResponse = ErrorResponse.of(ERROR_CODE, ERROR_MESSAGE, "/pub/chat/123");
+      WebSocketErrorEvent event = new WebSocketErrorEvent(USER_ID, ERROR_CHANNEL, errorResponse);
+
+      willThrow(new RuntimeException("메시징 실패"))
+          .given(messagingTemplate)
+          .convertAndSendToUser(any(), any(), any());
+
+      // when & then - 예외가 전파되지 않아야 함
+      listener.handleWebSocketError(event);
+
+      verify(messagingTemplate).convertAndSendToUser(USER_ID, ERROR_CHANNEL, errorResponse);
+    }
+
+    @Test
+    @DisplayName("unknown 채널로 에러를 전송할 수 있다")
+    void shouldSendErrorToUnknownChannel() {
+      // given
+      ErrorResponse errorResponse =
+          ErrorResponse.of(ERROR_CODE, ERROR_MESSAGE, "/pub/other/message");
+      WebSocketErrorEvent event =
+          new WebSocketErrorEvent(USER_ID, "/sub/errors/unknown", errorResponse);
+
+      // when
+      listener.handleWebSocketError(event);
+
+      // then
+      verify(messagingTemplate).convertAndSendToUser(USER_ID, "/sub/errors/unknown", errorResponse);
+    }
+  }
+}


### PR DESCRIPTION
JwtWebSocketInterceptor와 SimpMessagingTemplate 간의 순환 참조 문제를 이벤트 기반 아키텍처로 해결하여 의존성 구조를 개선했습니다.

주요 변경사항:
- WebSocketErrorEvent 레코드 추가: 에러 전송 이벤트 정의
- WebSocketErrorEventListener 추가: 이벤트를 받아 실제 메시지 전송 처리
- JwtWebSocketInterceptor 리팩토링:
  * SimpMessagingTemplate 의존성 제거
  * ApplicationEventPublisher로 에러 이벤트 발행
  * SEND 에러 처리 방식을 직접 전송에서 이벤트 발행으로 변경
- 테스트 코드 업데이트:
  * JwtWebSocketInterceptorTest: 이벤트 발행 검증으로 수정
  * WebSocketErrorEventListenerTest: 리스너 동작 검증 테스트 추가

기술적 개선:
- 순환 참조 해결: @Lazy 임시 방편 대신 이벤트 기반 아키텍처 적용
- 관심사 분리: 인터셉터는 이벤트 발행, 리스너는 메시지 전송 처리
- 테스트 용이성: ApplicationEventPublisher 모킹으로 단위 테스트 간소화

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Pull Request

## 변경 사항
<!-- 이 PR에서 변경한 내용을 간단히 설명해주세요 -->

-

### 관련 이슈
<!-- 관련된 GitHub 이슈를 연결하세요 (예: Closes #123, Fixes #456) -->

-

### 변경 유형

- [ ] `feat`: 새로운 기능 추가
- [ ] `fix`: 버그 수정
- [ ] `design`: UI 디자인 변경
- [ ] `docs`: 문서 변경
- [ ] `chore`: 빌드 설정, 의존성, 환경 설정 변경
- [ ] `refactor`: 코드 리팩토링 혹은 성능 개선
- [ ] `test`: 테스트 코드 추가 또는 수정
- [ ] `comment`: 주석 추가 및 수정
- [ ] `style`: 코드 포맷팅 (기능 변경 없음)
- [ ] `remove`: 파일, 기능, 의존성 제거
- [ ] `ci`: CI 설정 변경
- [ ] `cd`: CD 설정 변경

## 체크리스트

- [ ] 테스트 작성 및 통과 (커버리지 60% 이상)
- [ ] `./gradlew spotlessApply` 실행
- [ ] Conventional Commits 준수


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * WebSocket 오류 처리 방식을 개선하여 시스템의 안정성과 확장성을 향상시켰습니다. 내부 아키텍처가 재구성되어 컴포넌트 간 결합도가 감소했으며, 오류 전달 메커니즘이 더욱 견고해졌습니다.

* **테스트**
  * 오류 처리 로직에 대한 추가 테스트 케이스가 포함되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->