### PR TITLE
docs: 여행 일차별 일정 조회 API 문서 개선 및 타입 안정성 강화

### DIFF
--- a/src/main/java/com/swygbro/airoad/backend/trip/presentation/web/TripPlanApi.java
+++ b/src/main/java/com/swygbro/airoad/backend/trip/presentation/web/TripPlanApi.java
@@ -1,5 +1,7 @@
 package com.swygbro.airoad.backend.trip.presentation.web;
 
+import java.util.List;
+
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -19,6 +21,7 @@ import com.swygbro.airoad.backend.common.domain.dto.CommonResponse;
 import com.swygbro.airoad.backend.common.domain.dto.CursorPageResponse;
 import com.swygbro.airoad.backend.trip.domain.dto.request.TripPlanCreateRequest;
 import com.swygbro.airoad.backend.trip.domain.dto.request.TripPlanUpdateRequest;
+import com.swygbro.airoad.backend.trip.domain.dto.response.DailyPlanResponse;
 import com.swygbro.airoad.backend.trip.domain.dto.response.TripPlanDetailResponse;
 import com.swygbro.airoad.backend.trip.domain.dto.response.TripPlanResponse;
 
@@ -642,7 +645,7 @@ public interface TripPlanApi {
           Long tripPlanId);
 
   @Operation(
-      summary = "여행 일차별 일정 조회",
+      summary = "여행 일차별 일정 목록 조회",
       description = "tripPlanId를 이용하여 해당 여행의 모든 일차별 여행 일정을 조회합니다.",
       security = @SecurityRequirement(name = "bearerAuth"))
   @ApiResponses({
@@ -652,7 +655,45 @@ public interface TripPlanApi {
         content =
             @Content(
                 mediaType = "application/json",
-                schema = @Schema(implementation = CommonResponse.class))),
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "success": true,
+                              "status": 200,
+                              "data": [
+                                {
+                                  "id": 1,
+                                  "dayNumber": 1,
+                                  "date": "2025-12-01",
+                                  "title": "첫째 날 일정",
+                                  "description": "서울 주요 관광지 탐방",
+                                  "scheduledPlaces": [
+                                    {
+                                      "id": 1,
+                                      "placeId": 101,
+                                      "placeName": "경복궁",
+                                      "visitOrder": 1,
+                                      "category": "ATTRACTION",
+                                      "startTime": "09:00",
+                                      "endTime": "11:00",
+                                      "travelTime": 30,
+                                      "transportation": "PUBLIC_TRANSIT"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "id": 2,
+                                  "dayNumber": 2,
+                                  "date": "2025-12-02",
+                                  "title": "둘째 날 일정",
+                                  "description": "강남 지역 탐방",
+                                  "scheduledPlaces": []
+                                }
+                              ]
+                            }
+                            """))),
     @ApiResponse(
         responseCode = "401",
         description = "인증되지 않은 사용자",
@@ -670,7 +711,7 @@ public interface TripPlanApi {
                                 "timestamp": "2025-10-30T10:00:00",
                                 "code": "AUTH001",
                                 "message": "인증이 필요합니다.",
-                                "path": "/api/v1/daily-plans/123",
+                                "path": "/api/v1/trips/daily-plans/123",
                                 "errors": null
                               }
                             }
@@ -692,7 +733,7 @@ public interface TripPlanApi {
                                 "timestamp": "2025-10-30T10:00:00",
                                 "code": "TRIP102",
                                 "message": "여행 일정에 대한 접근 권한이 없습니다.",
-                                "path": "/api/v1/daily-plans/123",
+                                "path": "/api/v1/trips/daily-plans/123",
                                 "errors": null
                               }
                             }
@@ -714,14 +755,14 @@ public interface TripPlanApi {
                                 "timestamp": "2025-10-30T10:00:00",
                                 "code": "TRIP101",
                                 "message": "여행 일정을 찾을 수 없습니다.",
-                                "path": "/api/v1/daily-plans/123",
+                                "path": "/api/v1/trips/daily-plans/123",
                                 "errors": null
                               }
                             }
                             """)))
   })
   @GetMapping("/daily-plans/{tripPlanId}")
-  ResponseEntity<CommonResponse<Object>> getDailyPlans(
+  ResponseEntity<CommonResponse<List<DailyPlanResponse>>> getDailyPlans(
       @AuthenticationPrincipal UserPrincipal userPrincipal,
       @Parameter(description = "여행 계획 ID", required = true, example = "123") @PathVariable
           Long tripPlanId);

--- a/src/main/java/com/swygbro/airoad/backend/trip/presentation/web/TripPlanController.java
+++ b/src/main/java/com/swygbro/airoad/backend/trip/presentation/web/TripPlanController.java
@@ -125,7 +125,7 @@ public class TripPlanController implements TripPlanApi {
 
   @Override
   @GetMapping("/daily-plans/{tripPlanId}")
-  public ResponseEntity<CommonResponse<Object>> getDailyPlans(
+  public ResponseEntity<CommonResponse<List<DailyPlanResponse>>> getDailyPlans(
       @AuthenticationPrincipal UserPrincipal userPrincipal, @PathVariable Long tripPlanId) {
 
     List<DailyPlanResponse> dailyPlanResponseList =


### PR DESCRIPTION
## Summary
여행 일차별 일정 조회 API의 문서를 개선하고 타입 안정성을 강화했습니다.

## Changes

### 1. 타입 안정성 강화
- `getDailyPlans()` 리턴 타입: `ResponseEntity<CommonResponse<Object>>` → `ResponseEntity<CommonResponse<List<DailyPlanResponse>>>`
- API 인터페이스와 구현체 모두 구체적인 타입으로 변경
- Swagger UI에서 정확한 응답 타입 표시

### 2. API 문서 개선
- **Summary 명확화**: "여행 일차별 일정 조회" → "여행 일차별 일정 목록 조회"
- **200 응답 예시 추가**:
  - 2개의 일차별 일정 샘플 데이터
  - `scheduledPlaces` 배열 포함
  - 실제 응답 구조를 명확히 표현
- **API 경로 수정**: 모든 에러 응답의 path를 실제 경로로 수정
  - Before: `/api/v1/daily-plans/123`
  - After: `/api/v1/trips/daily-plans/123`

## Benefits
- 개발자가 Swagger UI에서 정확한 API 스펙 확인 가능
- 타입 안전성으로 컴파일 타임 에러 검출
- 명확한 응답 예시로 API 이해도 향상

## Test Plan
- [x] 기존 테스트 모두 통과
- [x] Swagger UI에서 문서 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * API 문서에서 일일 일정 조회 경로 오류 수정

* **개선 사항**
  * 일일 일정 목록 조회 응답 형식을 명확하게 개선하고 API 문서 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->